### PR TITLE
Correct bboxes_ex_msgs package name

### DIFF
--- a/yolov5_ros/package.xml
+++ b/yolov5_ros/package.xml
@@ -16,7 +16,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>cv_bridge</depend>
-  <depend>bbox_ex_msgs</depend>
+  <depend>bboxes_ex_msgs</depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
Your [bbox_ex_msgs](https://github.com/Ar-Ray-code/bbox_ex_msgs) package name is actually `bboxes_ex_msgs`. Just correcting that in the YOLOv5 ROS wrapper's `package.xml`.