### PR TITLE
Update Deprecated Option in setup.cfg for ROS2 Humble Compatibility

### DIFF
--- a/yolov5_ros/setup.cfg
+++ b/yolov5_ros/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/yolov5_ros
+script_dir=$base/lib/yolov5_ros
 [install]
-install-scripts=$base/lib/yolov5_ros
+install_scripts=$base/lib/yolov5_ros


### PR DESCRIPTION
## Summary of Changes
In the `yolov5_ros/setup.cfg` file, I have updated the use of the dash-separated `script-dir` to the underscore-separated `script_dir`. This change aligns with the requirements for ROS2 Humble compatibility and addresses the deprecation warning indicating that dash-separated names will not be supported in future versions.

## Background
With ROS2 Humble now in widespread use, it's crucial to ensure our packages are fully compatible with this latest version. Additionally, Python packaging tools are evolving, and it's essential to keep our configuration files up-to-date with the latest standards. The use of underscore-separated names is now the recommended practice for options in `setup.cfg`. This change is also validated under Python 3.10.12, ensuring compatibility with this Python version.

## Impact
This modification is a syntax update that is necessary for both ROS2 Humble compatibility and adherence to Python packaging standards. It's a straightforward change and does not affect the functionality of the package. However, it ensures that our package remains functional and compliant within the ROS2 Humble environment and with Python 3.10.12.

## Testing and Validation
I have thoroughly tested the changes to confirm that they do not introduce any issues in a ROS2 Humble environment running Python 3.10.12. The package continues to function as expected, and the updated `setup.cfg` aligns with current best practices in Python packaging and ROS2 requirements.

